### PR TITLE
Added ubsan exception

### DIFF
--- a/src/polish.c
+++ b/src/polish.c
@@ -209,6 +209,7 @@ static void get_ypol_from_yred(OSQPWorkspace *work, c_float *yred) {
   }
 }
 
+__attribute__((no_sanitize("implicit-conversion")))
 c_int polish(OSQPWorkspace *work) {
   c_int mred, polish_successful, exitflag;
   c_float *rhs_red;


### PR DESCRIPTION
Suppressing ubsan error related to C-based polymorphism implementation.
In C++ [this struct](https://github.com/glydways/osqp/blob/barzinm/ubsan-fix/lin_sys/direct/qdldl/qdldl_interface.h#L16) would be inherited from [this struct](https://github.com/glydways/osqp/blob/barzinm/ubsan-fix/include/types.h#L298).

That was causing `ubsan` error:
```
../third_party/osqp/src/polish.c:272:3: runtime error: call to function solve_linsys_qdldl through pointer to incorrect function type 'long long (*)(struct linsys_solver *, double *)'
```


